### PR TITLE
Fix Enum type using string starting with minus char

### DIFF
--- a/fixtures/test.wsdl
+++ b/fixtures/test.wsdl
@@ -91,6 +91,13 @@
           <s:documentation>The date and time when the process starts.</s:documentation>
         </s:annotation>
       </s:element>
+      <s:simpleType name="statusCodeType">
+        <s:restriction base="s:string">
+          <s:enumeration value="-1"/>
+          <s:enumeration value="0"/>
+          <s:enumeration value="1"/>
+        </s:restriction>
+    </s:simpleType>
     </s:schema>
   </wsdl:types>
   <wsdl:message name="GetInfoSoapIn">

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -485,7 +485,9 @@ func normalize(value string) string {
 		}
 		return -1
 	}
-
+	if strings.HasPrefix(value, "-") {
+		value = strings.Replace(value, "-", "Minus", 1)
+	}
 	return strings.Map(mapping, value)
 }
 

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -260,6 +260,39 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 
 }
 
+func TestEnumerationWithMinusSignString(t *testing.T) {
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp, err := g.Start()
+	if err != nil {
+		t.Error(err)
+	}
+
+	actual, err := getTypeDeclaration(resp, "StatusCodeTypeMinus1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `const StatusCodeTypeMinus1 StatusCodeType = "-1"`
+
+	if actual != expected {
+		t.Error("got \n" + actual + " want \n" + expected)
+	}
+
+	actual, err = getTypeDeclaration(resp, "StatusCodeType1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `const StatusCodeType1 StatusCodeType = "1"`
+
+	if actual != expected {
+		t.Error("got \n" + actual + " want \n" + expected)
+	}
+
+}
+
 func TestComplexTypeGeneratedCorrectly(t *testing.T) {
 	g, err := NewGoWSDL("fixtures/workday-time-min.wsdl", "myservice", false, true)
 	if err != nil {


### PR DESCRIPTION
- when a string start with minus like "-1" and another enum value is "1" the same enum type is generated and cause a go compilation error
- replace the "-" char with the word "Minus"